### PR TITLE
[SPORTS-13397] Exposed hasHost method on Routers to handle cases where e the host controller is destroyed or null

### DIFF
--- a/conductor/src/main/java/com/bluelinelabs/conductor/ActivityHostedRouter.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/ActivityHostedRouter.java
@@ -112,7 +112,7 @@ public class ActivityHostedRouter extends Router {
     }
 
     @Override
-    boolean hasHost() {
+    public boolean hasHost() {
         return lifecycleHandler != null;
     }
 

--- a/conductor/src/main/java/com/bluelinelabs/conductor/ControllerHostedRouter.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/ControllerHostedRouter.java
@@ -182,7 +182,7 @@ class ControllerHostedRouter extends Router {
     }
 
     @Override
-    boolean hasHost() {
+    public boolean hasHost() {
         return hostController != null;
     }
 
@@ -239,12 +239,7 @@ class ControllerHostedRouter extends Router {
         if (hostController != null && hostController.getRouter() != null) {
             return hostController.getRouter().getRootRouter();
         } else {
-            // A ControllerHostedRouter cannot be the root, avoids StackOverflowException, lets us track our bad behaviour better
-            if (hostController != null) {
-                throw new RuntimeException(String.format("%s is orphaned from its ActivityHostedRouter", hostController.getClass().getSimpleName()));
-            } else {
-                throw new RuntimeException("ControllerHostedRouter is orphaned from its ActivityHostedRouter and has no hostController");
-            }
+            return this;
         }
     }
 

--- a/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
+++ b/conductor/src/main/java/com/bluelinelabs/conductor/Router.java
@@ -903,7 +903,7 @@ public abstract class Router {
     abstract void registerForActivityResult(@NonNull String instanceId, int requestCode);
     abstract void unregisterForActivityResults(@NonNull String instanceId);
     abstract void requestPermissions(@NonNull String instanceId, @NonNull String[] permissions, int requestCode);
-    abstract boolean hasHost();
+    public abstract boolean hasHost();
     @NonNull abstract List<Router> getSiblingRouters();
     @NonNull abstract Router getRootRouter();
     @Nullable abstract TransactionIndexer getTransactionIndexer();


### PR DESCRIPTION
`hasHost` will allow us to stop the `StackOverflowError` and exit really. One of the cases this happens in when the `childController` is alive but the `hostController` is destroyed or null. This shouldn't happen because `childController` can't live without the `hostController`. However, this does happen and the exact reason is unknown. 